### PR TITLE
Problem with union method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,9 @@ impl UnionFind {
     /// canonical element of `i` in the old
     /// partition. Running time O(1).
     pub fn union(&mut self, i: usize, j: usize) {
-        self.parts[j] = self.parts[i];
+        let i_leader = self.find(i);
+        let j_leader = self.find(j);
+        self.parts[j_leader] = self.parts[i_leader];
     }
 
     /// Return a "canonical element" for the partition


### PR DESCRIPTION
Hi. I needed a very simple implementation of union-find and found your repo, but it seems the union method has a serious problem:
```
let mut uf = UnionFind::new(3);
uf.union(0, 1);
uf.union(2, 1);

assert!(uf.same(0, 2)); // Fails
```
This should form a single partition with all elements, but instead 2 partitions are created.

The PR fixes the problem.